### PR TITLE
Represent and partition netlist Nets.

### DIFF
--- a/rig/netlist.py
+++ b/rig/netlist.py
@@ -1,0 +1,44 @@
+"""Represent and work with vertices and netlists.
+"""
+
+
+class Net(object):
+    """A net represents connectivity from one vertex to many vertices.
+
+    Attributes
+    ----------
+    source : vertex
+        The vertex which is the source of the net.
+    weight : float or int
+        The "strength" of the net, in application specific units.
+    sinks : list
+        A list of vertices that the net connects to.
+    keyspace : :py:class:`~rig.keyspaces.Keyspace`
+        Keyspace for packets transmitted across this net.
+    """
+    __slots__ = ["source", "weight", "sinks", "keyspace"]
+
+    def __init__(self, source, sinks, weight=1.0, keyspace=None):
+        """Create a new Net.
+
+        Parameters
+        ----------
+        source : vertex
+        sinks : list or vertex
+            If a list of vertices is provided then the list is copied, whereas
+            if a single vertex is provided then this used to create the list of
+            sinks.
+        weight : float or int
+        keyspace : :py:class:`~rig.keyspaces.Keyspace`
+            Keyspace for packets transmitted across this net.
+        """
+        self.source = source
+        self.weight = weight
+        self.keyspace = keyspace
+
+        # If the sinks is a list then copy it, otherwise construct a new list
+        # containing the sink we were given.
+        if isinstance(sinks, list):
+            self.sinks = sinks[:]
+        else:
+            self.sinks = [sinks]

--- a/rig/tests/test_netlist.py
+++ b/rig/tests/test_netlist.py
@@ -1,0 +1,42 @@
+import mock
+
+from rig.netlist import Net
+
+
+class Vertex(object):
+    """Represents an object that could be the source or sink of a net."""
+    pass
+
+
+class TestNet(object):
+    def test_init_with_list(self):
+        source = Vertex()
+        sinks = [Vertex() for _ in range(3)]
+
+        net = Net(source, sinks, 0.5)
+
+        # Assert that the source object is the same but that the sinks list has
+        # been copied.
+        assert net.source is source
+        assert net.sinks is not sinks
+        assert net.sinks == sinks
+        assert net.weight == 0.5
+
+    def test_init_with_object(self):
+        source = Vertex()
+        sink = Vertex()
+
+        net = Net(source, sink, 5)
+
+        # Assert that the sinks is a list of the 1 sink we provided.
+        assert net.source is source
+        assert net.sinks == [sink]
+        assert net.weight == 5
+
+    def test_init_with_keyspace(self):
+        source = Vertex()
+        sinks = [Vertex() for _ in range(5)]
+        ks = mock.Mock()
+
+        net = Net(source, sinks, 1, keyspace=ks)
+        assert net.keyspace == ks


### PR DESCRIPTION
A (basic) net has a source, a weight and a set of sinks.

Nets can be partitioned by replacing sinks or sources by either single
objects or lists of replacements.  See the docstring for
`rig.netlist.Net.partition`.