### PR TITLE
Generate app_ptr tables.

### DIFF
--- a/rig/regions/app_ptr.py
+++ b/rig/regions/app_ptr.py
@@ -1,0 +1,52 @@
+"""Generate app_ptr tables for data stored in SDRAM.
+"""
+import struct
+
+
+def create_app_ptr_table(regions, vertex_slice=slice(0, 1),
+                         magic_num=0xAD130AD6, version=0x00010000,
+                         timer_period=1000):
+    """Create a bytestring representing the application pointer table
+    indicating the location of regions in SDRAM.
+
+    Parameters
+    ----------
+    regions : dict
+        A mapping on integers to `rig.regions.Region` instances that are to be
+        stored in memory.  The integer is the "number" of the region.
+    vertex_slice : :py:func:`slice`
+        The slice that should be applied to each region.  In the case of
+        unsliced regions this may be left with its default value.
+    magic_num : int
+    version : int
+    timer_period : int
+
+    Returns
+    -------
+    bytestring
+        A string of bytes which should be written into memory immediately
+        before any region data.
+    """
+    # Pack the header data
+    header = [magic_num, version, timer_period]
+
+    # Add region offsets
+    max_index = 0
+    table = []
+    if len(regions) > 0:
+        max_index = max(sorted(regions.keys())) + 1
+        table = [0] * max_index
+        offset = (max_index + len(header)) * 4
+
+    for index in sorted(regions.keys()):
+        # Set the offset for this region
+        table[index] = offset
+
+        # Then increment to account for the data stored in this region
+        offset += regions[index].sizeof(vertex_slice)
+
+        # Progress to the next word boundary
+        offset += (4 - (offset & 0x3)) & 0x3
+
+    return struct.pack('<' + 'I' * (max_index + len(header)),
+                       *(header + table))

--- a/rig/regions/tests/test_app_ptr.py
+++ b/rig/regions/tests/test_app_ptr.py
@@ -1,0 +1,72 @@
+import mock
+import pytest
+import struct
+from ..app_ptr import create_app_ptr_table
+
+
+@pytest.mark.parametrize(
+    "magic_num, version, timer_period",
+    [(0xAD130AD6, 0x12341234, 1000),
+     (0xFFFFAAAA, 0x00001000, 1234)])
+def test_create_app_ptr_no_regions(magic_num, version, timer_period):
+    """Creating an application pointer table with no regions should just write
+    out header.
+    """
+    assert (create_app_ptr_table({}, magic_num=magic_num, version=version,
+                                 timer_period=timer_period) ==
+            struct.pack('3I', magic_num, version, timer_period))
+
+
+def test_create_app_ptr():
+    """Create a app_ptr table with entries of different sizes and with missing
+    regions.
+    """
+    # Region 0 -> doesn't align on words
+    r0 = mock.Mock(name="region 0", spec_set=['sizeof'])
+    r0.sizeof.return_value = 3
+
+    # Region 1 is missing
+
+    # Region 2 is missing
+
+    # Region 3 -> 75 words
+    r3 = mock.Mock(name="region 3", spec_set=['sizeof'])
+    r3.sizeof.return_value = 75 * 4
+
+    # Region 4 -> 2 bytes
+    r4 = mock.Mock(name="region 4", spec_set=['sizeof'])
+    r4.sizeof.return_value = 2
+
+    # Region 5 -> 1 bytes
+    r5 = mock.Mock(name="region 5", spec_set=['sizeof'])
+    r5.sizeof.return_value = 1
+
+    # Create the region dictionary
+    regions = {0: r0, 3: r3, 4: r4, 5: r5}
+
+    # Get the app pointer table
+    sl = mock.Mock(name="slice")
+    table = create_app_ptr_table(regions, sl)
+
+    # Check the length of the table
+    assert len(table) == (3 + 6) * 4  # 3 header words, 5 regions
+
+    # Region 0 should be offset 36 bytes
+    assert table[12:16] == struct.pack('<I', 36)
+
+    # Neither region 1 or 2 exist
+    assert (table[16:20] == b'\x00' * 4) or (table[16:20] == b'\xff' * 4)
+    assert (table[20:24] == b'\x00' * 4) or (table[20:24] == b'\xff' * 4)
+
+    # Region 3 should be offset 36 + 3 + 1 bytes (40)
+    assert table[24:28] == struct.pack('<I', 40)
+
+    # Region 4 should be offset 40 + 300 bytes
+    assert table[28:32] == struct.pack('<I', 340)
+
+    # Region 5 should be offset 340 + 4 bytes
+    assert table[32:36] == struct.pack('<I', 344)
+
+    # Check each region was called with the same vertex slice
+    for r in (r0, r3, r4, r5):
+        r.sizeof.assert_called_once_with(sl)


### PR DESCRIPTION
Takes a dictionary mapping region index to regions and then returns a
bytestring of the app_ptr table.

Fulfils #9 